### PR TITLE
fix: Date for `OnDeploy` is always 1 day ahead

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export interface AtProps {
 export function dateToCron(date:Date) {
   const minutes = date.getUTCMinutes();
   const hours = date.getUTCHours();
-  const days = date.getDate() + 1;
+  const days = date.getDate();
   const months = date.getUTCMonth() + 1;
   const years = date.getUTCFullYear();
 

--- a/test/__snapshots__/onetimeevent.test.ts.snap
+++ b/test/__snapshots__/onetimeevent.test.ts.snap
@@ -12,7 +12,7 @@ Object {
   "Resources": Object {
     "triggerImmediate338B3A22": Object {
       "Properties": Object {
-        "ScheduleExpression": "cron(33 20 14 1 ? 2020)",
+        "ScheduleExpression": "cron(33 15 14 1 ? 2020)",
         "State": "ENABLED",
       },
       "Type": "AWS::Events::Rule",

--- a/test/__snapshots__/onetimeevent.test.ts.snap
+++ b/test/__snapshots__/onetimeevent.test.ts.snap
@@ -12,7 +12,7 @@ Object {
   "Resources": Object {
     "triggerImmediate338B3A22": Object {
       "Properties": Object {
-        "ScheduleExpression": "cron(10 0 16 1 ? 2020)",
+        "ScheduleExpression": "cron(33 20 14 1 ? 2020)",
         "State": "ENABLED",
       },
       "Type": "AWS::Events::Rule",

--- a/test/__snapshots__/onetimeevent.test.ts.snap
+++ b/test/__snapshots__/onetimeevent.test.ts.snap
@@ -12,7 +12,7 @@ Object {
   "Resources": Object {
     "triggerImmediate338B3A22": Object {
       "Properties": Object {
-        "ScheduleExpression": "cron(33 15 14 1 ? 2020)",
+        "ScheduleExpression": "cron(33 10 15 1 ? 2020)",
         "State": "ENABLED",
       },
       "Type": "AWS::Events::Rule",

--- a/test/onetimeevent.test.ts
+++ b/test/onetimeevent.test.ts
@@ -3,7 +3,7 @@ import { Template } from 'aws-cdk-lib/assertions';
 import * as oneTimeEvents from '../src/index';
 
 const date = new Date('2020-01-15');
-date.setHours(15);
+date.setHours(10);
 date.setMinutes(23);
 
 jest.setSystemTime(date.getTime());

--- a/test/onetimeevent.test.ts
+++ b/test/onetimeevent.test.ts
@@ -2,7 +2,11 @@ import { aws_events as events, App, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import * as oneTimeEvents from '../src/index';
 
-jest.setSystemTime(new Date('2020-01-15').getTime());
+const date = new Date('2020-01-15');
+date.setHours(15);
+date.setMinutes(23);
+
+jest.setSystemTime(date.getTime());
 
 test('Snapshot', () => {
   const app = new App();


### PR DESCRIPTION
Not sure whats going on here. This doesn't happen in testing but does when used.